### PR TITLE
Updated sshtml files so that Visual Studio 2012 doesn't complain

### DIFF
--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Views/index.sshtml
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Views/index.sshtml
@@ -1,7 +1,7 @@
-﻿<!doctype html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>$safeprojectname$</title>
 
 	<style type="text/css">

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.SelfHost/Views/index.sshtml
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.SelfHost/Views/index.sshtml
@@ -1,7 +1,7 @@
-﻿<!doctype html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>$safeprojectname$</title>
 
 	<style type="text/css">

--- a/src/Nancy.Templates/Nancy.Templates.VisualBasic.AspNetHost/Views/index.sshtml
+++ b/src/Nancy.Templates/Nancy.Templates.VisualBasic.AspNetHost/Views/index.sshtml
@@ -1,7 +1,7 @@
-﻿<!doctype html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>$safeprojectname$</title>
 
 	<style type="text/css">

--- a/src/Nancy.Templates/Nancy.Templates.VisualBasic.SelfHost/Views/index.sshtml
+++ b/src/Nancy.Templates/Nancy.Templates.VisualBasic.SelfHost/Views/index.sshtml
@@ -1,7 +1,7 @@
-﻿<!doctype html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>$safeprojectname$</title>
 
 	<style type="text/css">


### PR DESCRIPTION
VS 2012 shows these two things as errors. Both the previous version and the new version are technically valid html5, I just don't like seeing errors in VS. Interestingly, they don't appear as errors in the cshtml or vbhtml versions of the file.
