### PR TITLE
Added automated template builder utility & synced project/web.config

### DIFF
--- a/src/Nancy.Templates.Builder/App.config
+++ b/src/Nancy.Templates.Builder/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+  </startup>
+</configuration>

--- a/src/Nancy.Templates.Builder/Extensions/ProjectXElement.cs
+++ b/src/Nancy.Templates.Builder/Extensions/ProjectXElement.cs
@@ -1,0 +1,47 @@
+﻿namespace Nancy.Templates.Builder.Extensions
+{
+    /// <summary>
+    /// MSBuild Project Xml Element XNames
+    /// </summary>
+    public static class ProjectXElement
+    {
+        private const string XmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+        
+        /// <summary>
+        /// Project root element
+        /// </summary>
+        public const string Project = "{" + XmlNamespace + "}Project";
+        
+        /// <summary>
+        /// Item group element
+        /// </summary>
+        public const string ItemGroup = "{" + XmlNamespace + "}ItemGroup";
+        
+        /// <summary>
+        /// Assembly reference element
+        /// </summary>
+        public const string Reference = "{" + XmlNamespace + "}Reference";
+
+        /// <summary>
+        /// Namespace import element
+        /// </summary>
+        public const string Import  = "{" + XmlNamespace + "}Import";
+
+        /// <summary>
+        /// Namespace compile element
+        /// </summary>
+        public const string Compile  = "{" + XmlNamespace + "}Compile";
+
+        /// <summary>
+        /// Namespace property group element
+        /// </summary>
+        public const string PropertyGroup  = "{" + XmlNamespace + "}PropertyGroup";
+
+        /// <summary>
+        /// Namespace root namespace element
+        /// </summary>
+        public const string RootNamespace  = "{" + XmlNamespace + "}RootNamespace";
+
+
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateConfigExtensions.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateConfigExtensions.cs
@@ -1,0 +1,37 @@
+﻿namespace Nancy.Templates.Builder.Extensions
+{
+    using System.IO;
+    using Model;
+
+    /// <summary>
+    /// Containing extensions for <see cref="TemplateConfig"/> implementations.
+    /// </summary>
+    public static class TemplateConfigExtensions
+    {
+        /// <summary>
+        /// Parses MSBuild Project from Config
+        /// </summary>
+        /// <param name="config">source template config</param>
+        /// <returns>Parsed template</returns>
+        public static Template ParseProjectFileFromConfig(this TemplateConfig config)
+        {
+            var template =
+                new Template
+                {
+                    Name = config.Name,
+                    DefaultName = config.DefaultName,
+                    Description = config.Description,
+                    ProjectFileName = config.ProjectFileName,
+                    ProjectType = config.ProjectType,
+                    ProjectName = Path.GetFileName(config.ProjectFileName).Replace(string.Concat(".", config.ProjectType), ""),
+                    TargetPath = Path.Combine(StaticConfig.PackagePath, string.Concat(config.Name, ".zip"))
+                };
+            string defaultNamespace;
+            template.Files = template.ParseProjectFiles(out defaultNamespace);
+            template.ProjectDefaultNamespace = defaultNamespace;
+            template.ProjectFolder = template.ParseProjectFolders();
+            template.Packages = template.ParseProjectPackages();
+            return template;
+        }
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateExportXmlExtensions.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateExportXmlExtensions.cs
@@ -1,0 +1,138 @@
+﻿namespace Nancy.Templates.Builder.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Text;
+    using System.Xml;
+    using System.Xml.Linq;
+    using Model;
+
+    /// <summary>
+    /// Containing extensions for <see cref="Template"/> xml export implementations.
+    /// </summary>
+    public static class TemplateExportXmlExtensions
+    {
+        /// <summary>
+        /// Template manifest target file name
+        /// </summary>
+        private const string VsTemplate = "MyTemplate.vstemplate";
+
+        /// <summary>
+        /// Template Xml format settings, skip declaration and bom
+        /// </summary>
+        private static readonly XmlWriterSettings VsTemplateXmlWriterSettings = new XmlWriterSettings
+        {
+            OmitXmlDeclaration = true,
+            Indent = true,
+            Encoding = new UTF8Encoding(false)
+        };
+
+        /// <summary>
+        /// Adds template manifest to zip archive
+        /// </summary>
+        /// <param name="template">source template</param>
+        /// <param name="archive">target zip file</param>
+        public static void AddVsMyTemplate(this Template template, ZipArchive archive)
+        {
+            var xVsTemplate =
+                template.ToVsTemplate();
+
+            var entry =
+                archive.CreateEntry(VsTemplate, CompressionLevel.Optimal);
+
+            using (var target = entry.Open())
+            {
+                using (var xw = XmlWriter.Create(target, VsTemplateXmlWriterSettings))
+                {
+                    xVsTemplate.Save(xw);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates template manifest xml from given template
+        /// </summary>
+        /// <param name="template">source template</param>
+        /// <returns>template manifest xml</returns>
+        private static XElement ToVsTemplate(this Template template)
+        {
+            Func<IList<TemplateFile>, IList<XElement>> filesToXml =
+                files => files.OrderBy(file => file.Name)
+                    .Select(file => new XElement(
+                        TemplateXElement.ProjectItem,
+                        new XAttribute(TemplateXAttribute.ReplaceParameters, file.ReplaceParameters),
+                        new XAttribute(TemplateXAttribute.TargetFileName, file.Name),
+                        file.Name
+                        )).ToArray();
+
+            Func<TemplateFolder, IList<XElement>> folderToXml = null;
+            folderToXml = folder => folder
+                .Folders
+                .Select(
+                    subfolder => new XElement(
+                        TemplateXElement.Folder,
+                        new XAttribute(TemplateXAttribute.Name, subfolder.Name),
+                        new XAttribute(TemplateXAttribute.TargetFolderName, subfolder.Name),
+                        folderToXml(subfolder)
+                        ))
+                .Union(
+                    filesToXml(folder.Files))
+                .ToArray();
+
+
+            var xVsTemplate =
+                XElement.Parse(TemplateXElement.Root);
+
+            xVsTemplate.Add(
+                new XElement(
+                    TemplateXElement.TemplateData,
+                    new XElement(TemplateXElement.Name, template.Name),
+                    new XElement(TemplateXElement.Description, template.Description),
+                    new XElement(TemplateXElement.ProjectType, template.ProjectType),
+                    new XElement(TemplateXElement.ProjectSubType, "\r\n    "),
+                    new XElement(TemplateXElement.SortOrder, 1000),
+                    new XElement(TemplateXElement.CreateNewFolder, true),
+                    new XElement(TemplateXElement.DefaultName, template.DefaultName),
+                    new XElement(TemplateXElement.ProvideDefaultName, true),
+                    new XElement(TemplateXElement.LocationField, "Enabled"),
+                    new XElement(TemplateXElement.EnableLocationBrowseButton, true),
+                    new XElement(TemplateXElement.Icon, StaticConfig.IconTemplateFile.ZipPath),
+                    new XElement(TemplateXElement.PreviewImage, StaticConfig.PreviewTemplateFile.ZipPath)
+                    ),
+                new XElement(
+                    TemplateXElement.TemplateContent,
+                    new XElement(
+                        TemplateXElement.Project,
+                        new XAttribute(TemplateXAttribute.TargetFileName, template.ProjectName),
+                        new XAttribute(TemplateXAttribute.File, template.ProjectName),
+                        new XAttribute(TemplateXAttribute.ReplaceParameters, true),
+                        folderToXml(template.ProjectFolder)
+                        )
+                    ),
+                new XElement(
+                    TemplateXElement.WizardExtension,
+                    new XElement(
+                        TemplateXElement.Assembly,
+                        "NuGet.VisualStudio.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"),
+                    new XElement(
+                        TemplateXElement.FullClassName,
+                        "NuGet.VisualStudio.TemplateWizard")),
+                new XElement(
+                    TemplateXElement.WizardData,
+                    new XElement(
+                       TemplateXElement.Packages,
+                       new XAttribute(TemplateXAttribute.Repository, "extension"),
+                       new XAttribute(TemplateXAttribute.RepositoryId, "0640dbb9-555b-4041-8b43-1dc895633e17"),
+                       template.Packages.Select(
+                       package=>new XElement(
+                            TemplateXElement.Package,
+                            new XAttribute(TemplateXAttribute.Id, package.Id),
+                            new XAttribute(TemplateXAttribute.Version, package.Version)
+                           )))));
+
+            return xVsTemplate;
+        }
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateImportXmlExtensions.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateImportXmlExtensions.cs
@@ -1,0 +1,201 @@
+﻿using System.Data;
+
+namespace Nancy.Templates.Builder.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Xml.Linq;
+    using Model;
+
+    /// <summary>
+    /// Containing extensions for <see cref="Template"/> xml import implementations.
+    /// </summary>
+    public static class TemplateImportXmlExtensions
+    {
+        /// <summary>
+        /// Parses available files in MSBuild project file
+        /// </summary>
+        /// <param name="template">source template</param>
+        /// <param name="defaultNamespace">project default namespace</param>
+        /// <returns>Found files in project file</returns>
+        /// <exception cref="DirectoryNotFoundException">if project folder not found</exception>
+        /// <exception cref="NoNullAllowedException">if project namespace not found</exception>
+        public static TemplateFile[] ParseProjectFiles(this Template template, out string defaultNamespace)
+        {
+            var rootPath =
+                Path.GetDirectoryName(template.ProjectFileName);
+
+            if (string.IsNullOrEmpty(rootPath) || !Directory.Exists(rootPath))
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            var xDoc =
+                XDocument.Load(template.ProjectFileName);
+
+            defaultNamespace =
+                (
+                    from project in xDoc.Elements(ProjectXElement.Project)
+                    from propertyGroup in project.Elements(ProjectXElement.PropertyGroup)
+                    from rootNameSpace in propertyGroup.Elements(ProjectXElement.RootNamespace)
+                    select rootNameSpace.Value).FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(defaultNamespace))
+                throw new NoNullAllowedException("No default namespace found");
+
+
+            return (
+                from project in xDoc.Elements(ProjectXElement.Project)
+                from itemGroup in project.Elements(ProjectXElement.ItemGroup)
+                from element in itemGroup.Elements()
+                where element.Name != ProjectXElement.Reference && element.Name!=ProjectXElement.Import
+                from include in element.Attributes("Include")
+                let value = include.Value
+                where !string.IsNullOrEmpty(value)
+                select new TemplateFile
+                {
+                    Name = Path.GetFileName(value),
+                    FilePath = Path.Combine(rootPath, value),
+                    ZipPath = value,
+                    ReplaceParameters = CheckIfReplaceFile(value),
+                    Compile = element.Name == ProjectXElement.Compile
+                })
+                .Union(
+                    new[]
+                    {
+                        new TemplateFile
+                        {
+                            Name = template.ProjectName,
+                            FilePath = template.ProjectFileName,
+                            ZipPath = template.ProjectName,
+                            Exclude = true,
+                            ReplaceParameters = true,
+                            Compile = true
+                        },
+                        StaticConfig.IconTemplateFile,
+                        StaticConfig.PreviewTemplateFile
+                    })
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Parses project folder / file structure
+        /// </summary>
+        /// <param name="template">source template</param>
+        /// <returns>Template folder structure</returns>
+        /// <exception cref="DirectoryNotFoundException">if project folder not found</exception>
+        public static TemplateFolder ParseProjectFolders(this Template template)
+        {
+            var rootPath =
+                Path.GetDirectoryName(template.ProjectFileName);
+
+            if (string.IsNullOrEmpty(rootPath) || !Directory.Exists(rootPath))
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            var fileLookup =
+                template.Files
+                .Where(file => !file.Exclude)
+                .ToLookup(key => Path.GetDirectoryName(key.ZipPath), value => value);
+
+            var projectDir =
+                new DirectoryInfo(rootPath);
+
+            Func<IEnumerable<DirectoryInfo>, string, TemplateFolder[]> toTemplateFolder =
+                null;
+
+            toTemplateFolder =
+                (directories, zipPath) => (
+                    from dir in directories
+                    let curZipPath =
+                        (dir == projectDir)
+                            ? string.Empty
+                            : string.Concat(zipPath, "\\", dir.Name).TrimStart('\\')
+                    let files = fileLookup[curZipPath].ToArray()
+                    where files.Length > 0
+                    select new TemplateFolder
+                            {
+                                Name = dir.Name,
+                                Folders = toTemplateFolder(dir.EnumerateDirectories(), curZipPath),
+                                Files = files
+                            })
+                    .ToArray();
+
+            return toTemplateFolder(
+                new[] { projectDir },
+                string.Empty)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Parse project packages.config
+        /// </summary>
+        /// <param name="template"></param>
+        /// <returns></returns>
+        /// <exception cref="DirectoryNotFoundException">project directory not found</exception>
+        public static TemplatePackage[] ParseProjectPackages(this Template template)
+        {
+            var rootPath =
+                Path.GetDirectoryName(template.ProjectFileName);
+
+            if (string.IsNullOrEmpty(rootPath) || !Directory.Exists(rootPath))
+            {
+                throw new DirectoryNotFoundException();
+            }
+
+            var packageConfigFilename =
+                Path.Combine(
+                    rootPath,
+                    "packages.config");
+
+            if (!File.Exists(packageConfigFilename))
+                return new TemplatePackage[0];
+
+            var xDoc =
+                XDocument.Load(packageConfigFilename);
+
+            return (
+                from packages in xDoc.Elements("packages")
+                from package in packages.Elements("package")
+                select new TemplatePackage
+                {
+                    Id = package.Attributes("id").Select(id => id.Value).FirstOrDefault(),
+                    Version = package.Attributes("version").Select(version => version.Value).FirstOrDefault()
+                }
+                ).ToArray();
+        }
+
+        /// <summary>
+        /// Check if template variables should be replace on given file
+        /// </summary>
+        /// <param name="filePath">path to source file</param>
+        /// <returns>boolean</returns>
+        private static bool CheckIfReplaceFile(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                return false;
+            }
+
+            var extension =
+                Path.GetExtension(filePath)
+                .ToLower();
+
+            switch (extension)
+            {
+                case ".resx":
+                case ".png":
+                case ".jpg":
+                case ".dll":
+                case "":
+                    return false;
+
+                default:
+                    return true;
+            }
+        }
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateXAttribute.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateXAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace Nancy.Templates.Builder.Extensions
+{
+    /// <summary>
+    /// VSTemplate Xml Attributes XNames constants
+    /// </summary>
+    /// <remarks>
+    /// TODO: Doument attributes
+    /// </remarks>
+    internal static class TemplateXAttribute
+    {
+        public const string Name = "Name";
+        public const string TargetFileName = "TargetFileName";
+        public const string ReplaceParameters = "ReplaceParameters";
+        public const string File = "File";
+        public const string TargetFolderName = "TargetFolderName";
+        public const string Repository = "repository";
+        public const string RepositoryId = "repositoryId";
+        public const string Id = "id";
+        public const string Version = "version";
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateXElement.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateXElement.cs
@@ -1,0 +1,38 @@
+﻿namespace Nancy.Templates.Builder.Extensions
+{
+    /// <summary>
+    /// VSTemplate Xml Element XNames constants
+    /// </summary>
+    /// <remarks>
+    /// TODO: Doument element types
+    /// </remarks>
+    internal static class TemplateXElement
+    {
+        private const string TemplateXmlNamespace = "http://schemas.microsoft.com/developer/vstemplate/2005";
+        public const string Root = "<VSTemplate Version=\"3.0.0\" xmlns=\"" + TemplateXmlNamespace + "\" Type=\"Project\" />";
+        public const string TemplateData = "{" + TemplateXmlNamespace + "}TemplateData";
+        public const string TemplateContent = "{" + TemplateXmlNamespace + "}TemplateContent";
+        public const string Name = "{" + TemplateXmlNamespace + "}Name";
+        public const string Description = "{" + TemplateXmlNamespace + "}Description";
+        public const string ProjectType = "{" + TemplateXmlNamespace + "}ProjectType";
+        public const string ProjectSubType = "{" + TemplateXmlNamespace + "}ProjectSubType";
+        public const string SortOrder = "{" + TemplateXmlNamespace + "}SortOrder";
+        public const string CreateNewFolder = "{" + TemplateXmlNamespace + "}CreateNewFolder";
+        public const string DefaultName = "{" + TemplateXmlNamespace + "}DefaultName";
+        public const string ProvideDefaultName = "{" + TemplateXmlNamespace + "}ProvideDefaultName";
+        public const string LocationField = "{" + TemplateXmlNamespace + "}LocationField";
+        public const string EnableLocationBrowseButton = "{" + TemplateXmlNamespace + "}EnableLocationBrowseButton";
+        public const string Icon = "{" + TemplateXmlNamespace + "}Icon";
+        public const string PreviewImage = "{" + TemplateXmlNamespace + "}PreviewImage";
+        public const string Project = "{" + TemplateXmlNamespace + "}Project";
+        public const string ProjectItem = "{" + TemplateXmlNamespace + "}ProjectItem";
+        public const string Folder = "{" + TemplateXmlNamespace + "}Folder";
+        public const string WizardExtension = "{" + TemplateXmlNamespace + "}WizardExtension";
+        public const string Assembly = "{" + TemplateXmlNamespace + "}Assembly";
+        public const string FullClassName = "{" + TemplateXmlNamespace + "}FullClassName";
+        public const string WizardData = "{" + TemplateXmlNamespace + "}WizardData";
+        public const string Packages = "{" + TemplateXmlNamespace + "}packages";
+        public const string Package = "{" + TemplateXmlNamespace + "}package";
+        
+    }
+}

--- a/src/Nancy.Templates.Builder/Extensions/TemplateZipArchiveExtensions.cs
+++ b/src/Nancy.Templates.Builder/Extensions/TemplateZipArchiveExtensions.cs
@@ -1,0 +1,92 @@
+﻿using System.Linq;
+using System.Text;
+
+namespace Nancy.Templates.Builder.Extensions
+{
+    using System;
+    using System.IO;
+    using System.IO.Compression;
+    using Model;
+
+    /// <summary>
+    /// Containing extensions for <see cref="Template"/> zip archive implementations.
+    /// </summary>
+    public static class TemplateZipArchiveExtensions
+    {
+        /// <summary>
+        /// Creates template zip archive, adds file and manifest
+        /// </summary>
+        /// <param name="template">source template</param>
+        public static void CreateTemplateZip(this Template template)
+        {
+            using (var fileStream = File.Create(template.TargetPath))
+            {
+                using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create))
+                {
+                    Array.ForEach(
+                        template.Files,
+                        file=>archive.AddFileEntry(file, template.ProjectDefaultNamespace));
+
+                    template.AddVsMyTemplate(archive);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper method to add template entry to zip archive
+        /// </summary>
+        /// <param name="archive">target archive</param>
+        /// <param name="file">source file</param>
+        /// <param name="defaultNamespace">project default namespace</param>
+        private static void AddFileEntry(
+            this ZipArchive archive,
+            TemplateFile file,
+            string defaultNamespace
+            )
+        {
+            var fileExists =
+                File.Exists(file.FilePath);
+
+            var directoryExists =
+                !fileExists && Directory.Exists(file.FilePath);
+
+            if (!fileExists && !directoryExists)
+            {
+               throw new FileNotFoundException("Source file not found", file.FilePath);
+            }
+
+            var entry =
+                archive.CreateEntry(file.ZipPath, CompressionLevel.Optimal);
+
+            if (!fileExists)
+                return;
+
+            using (Stream
+                source = (file.Compile) ? PreProcessFile(file.FilePath, defaultNamespace) : File.OpenRead(file.FilePath),
+                target = entry.Open())
+            {
+                source.CopyTo(target);
+            }
+        }
+
+        private static Stream PreProcessFile(string filePath, string defaultNamespace)
+        {
+            var parsedFile =
+                File.ReadAllText(filePath, Encoding.UTF8);
+
+            parsedFile = parsedFile.Replace(defaultNamespace, "﻿$safeprojectname$").Replace(">..\\..\\packages", ">..\\packages");
+            //var ms =
+            //    new MemoryStream(
+            //       new UTF8Encoding(true).GetBytes(parsedFile)) {Position = 0};
+
+
+            //return ms;
+            var memoryStream = new MemoryStream();
+            var sw = new StreamWriter(memoryStream, Encoding.UTF8);
+            sw.Write(parsedFile);
+            sw.Flush();
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+    }
+}

--- a/src/Nancy.Templates.Builder/Model/Template.cs
+++ b/src/Nancy.Templates.Builder/Model/Template.cs
@@ -1,0 +1,63 @@
+﻿namespace Nancy.Templates.Builder.Model
+{
+    /// <summary>
+    /// Target templae blueprint
+    /// </summary>
+    public class Template
+    {
+        /// <summary>
+        /// Project file name with path
+        /// </summary>
+        public string ProjectFileName { get; set; }
+
+        /// <summary>
+        /// Project file name without path
+        /// </summary>
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Template name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Template default name
+        /// </summary>
+        public object DefaultName { get; set; }
+
+        /// <summary>
+        /// Template description
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Template zip archive desitination
+        /// </summary>
+        public string TargetPath { get; set; }
+
+        /// <summary>
+        /// Type of MSBuild project i.e. CSharp
+        /// </summary>
+        public string ProjectType { get; set; }
+
+        /// <summary>
+        /// All files to be added to zip Archive
+        /// </summary>
+        public TemplateFile[] Files { get; set; }
+
+        /// <summary>
+        /// All files to be added to template manifest
+        /// </summary>
+        public TemplateFolder ProjectFolder { get; set; }
+
+        /// <summary>
+        /// Project default name space
+        /// </summary>
+        public string ProjectDefaultNamespace { get; set; }
+
+        /// <summary>
+        /// Template Nuget packages
+        /// </summary>
+        public TemplatePackage[] Packages { get; set; }
+    }
+}

--- a/src/Nancy.Templates.Builder/Model/TemplateConfig.cs
+++ b/src/Nancy.Templates.Builder/Model/TemplateConfig.cs
@@ -1,0 +1,33 @@
+namespace Nancy.Templates.Builder.Model
+{
+    /// <summary>
+    /// Configuration that describes the template project
+    /// </summary>
+    public class TemplateConfig
+    {
+        /// <summary>
+        /// Name of template project also used for zip naming
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Name of template project also used for zip naming
+        /// </summary>
+        public string DefaultName { get; set; }
+
+        /// <summary>
+        /// Longer description of template project
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Path to source project
+        /// </summary>
+        public string ProjectFileName { get; set; }
+
+        /// <summary>
+        /// Type of project i.e. CSharp
+        /// </summary>
+        public string ProjectType { get; set; }
+    }
+}

--- a/src/Nancy.Templates.Builder/Model/TemplateFile.cs
+++ b/src/Nancy.Templates.Builder/Model/TemplateFile.cs
@@ -1,0 +1,38 @@
+﻿namespace Nancy.Templates.Builder.Model
+{
+    /// <summary>
+    /// Template file entry
+    /// </summary>
+    public class TemplateFile
+    {
+        /// <summary>
+        /// File name without path
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// File name with path
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// Relative file path used for zip entry
+        /// </summary>
+        public string ZipPath { get; set; }
+
+        /// <summary>
+        /// If file should be included in 
+        /// </summary>
+        public bool Exclude { get; set; }
+
+        /// <summary>
+        /// If template varianble replacements should be applied to file
+        /// </summary>
+        public bool ReplaceParameters { get; set; }
+
+        /// <summary>
+        /// If file should be compiled
+        /// </summary>
+        public bool Compile { get; set; }
+    }
+}

--- a/src/Nancy.Templates.Builder/Model/TemplateFolder.cs
+++ b/src/Nancy.Templates.Builder/Model/TemplateFolder.cs
@@ -1,0 +1,23 @@
+﻿namespace Nancy.Templates.Builder.Model
+{
+    /// <summary>
+    /// Template folder
+    /// </summary>
+    public class TemplateFolder
+    {
+        /// <summary>
+        /// Folder name
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Folder sub folders
+        /// </summary>
+        public TemplateFolder[] Folders { get; set; }
+
+        /// <summary>
+        /// Folder files
+        /// </summary>
+        public TemplateFile[] Files { get; set; }
+    }
+}

--- a/src/Nancy.Templates.Builder/Model/TemplatePackage.cs
+++ b/src/Nancy.Templates.Builder/Model/TemplatePackage.cs
@@ -1,0 +1,18 @@
+﻿namespace Nancy.Templates.Builder.Model
+{
+    /// <summary>
+    /// Template Nuget Package File
+    /// </summary>
+    public class TemplatePackage
+    {
+        /// <summary>
+        /// Package id
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Package version
+        /// </summary>
+        public string Version { get; set; }
+    }
+}

--- a/src/Nancy.Templates.Builder/Nancy.Templates.Builder.csproj
+++ b/src/Nancy.Templates.Builder/Nancy.Templates.Builder.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5FD39AFA-F3EC-475B-81FA-AA1633963138}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nancy.Templates.Builder</RootNamespace>
+    <AssemblyName>Nancy.Templates.Builder</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Nancy.Templates.Builder.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Extensions\ProjectXElement.cs" />
+    <Compile Include="Extensions\TemplateConfigExtensions.cs" />
+    <Compile Include="Extensions\TemplateImportXmlExtensions.cs" />
+    <Compile Include="Extensions\TemplateZipArchiveExtensions.cs" />
+    <Compile Include="Extensions\TemplateExportXmlExtensions.cs" />
+    <Compile Include="Model\TemplateConfig.cs" />
+    <Compile Include="Model\TemplatePackage.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Model\Template.cs" />
+    <Compile Include="Model\TemplateFile.cs" />
+    <Compile Include="Model\TemplateFolder.cs" />
+    <Compile Include="Extensions\TemplateXAttribute.cs" />
+    <Compile Include="Extensions\TemplateXElement.cs" />
+    <Compile Include="StaticConfig.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>$(TargetPath)</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Nancy.Templates.Builder/Program.cs
+++ b/src/Nancy.Templates.Builder/Program.cs
@@ -1,0 +1,72 @@
+﻿namespace Nancy.Templates.Builder
+{
+    using System;
+    using System.IO;
+    using Extensions;
+    using Model;
+
+    /// <summary>
+    /// Nancy Template Builder
+    /// </summary>
+    public static class Program
+    {
+        private static void Main()
+        {
+            Array.ForEach(
+                StaticConfig.TemplateConfigProjects,
+                CreateTemplateZipFromConfig);
+        }
+
+        private static void CreateTemplateZipFromConfig(TemplateConfig config)
+        {
+            try
+            {
+                Log("Start processing {0}", config.Name);
+
+                if (!File.Exists(config.ProjectFileName))
+                {
+                    Log("Missing project file {0}", config.ProjectFileName);
+                    Environment.Exit(1337);
+                }
+
+                var template =
+                    config.ParseProjectFileFromConfig();
+
+                if (template.Files == null || template.Files.Length == 0)
+                {
+                    Log("Failed to parse project file");
+                    Environment.Exit(1337);
+                }
+
+                if (template.ProjectFolder == null)
+                {
+                    Log("Failed to parse project folder structure");
+                    Environment.Exit(1337);
+                }
+
+                Log("Found {0} files in project", template.Files.Length);
+
+                template.CreateTemplateZip();
+
+                Log("Done processing {0}", config.Name);
+            }
+            catch (Exception ex)
+            {
+                Log("Error processing {0}\r\n{1}", config.Name, ex);
+                Environment.Exit(1337);
+            }
+        }
+
+        private static void Log(string format, params object[] args)
+        {
+            Console.WriteLine(
+                "[{0:HH:mm:ss}] {1}",
+                DateTime.Now,
+                (args == null || args.Length == 0)
+                    ? format
+                    : string.Format(
+                        format,
+                        args));
+        }
+    }
+}

--- a/src/Nancy.Templates.Builder/Properties/AssemblyInfo.cs
+++ b/src/Nancy.Templates.Builder/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("Nancy.Templates.Builder")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Nancy.Templates.Builder")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("75908c83-4aa4-4a20-b2a6-cf57a32a2b2d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Nancy.Templates.Builder/StaticConfig.cs
+++ b/src/Nancy.Templates.Builder/StaticConfig.cs
@@ -1,0 +1,123 @@
+﻿namespace Nancy.Templates.Builder
+{
+    using Model;
+
+    /// <summary>
+    /// Temporary static config until config loaded from file
+    /// </summary>
+    /// <remarks>
+    /// TODO: Load config from file, remove CSharp assumtions
+    /// </remarks>
+    public static class StaticConfig
+    {
+        private const string RootPath = @"..\..\..\Nancy.Templates\";
+        private const string PreviewImagePath = RootPath + "nancy-logo-preview.jpg";
+        private const string IconImagePath = RootPath + "nancy-logo-icon.jpg";
+        
+        /// <summary>
+        /// Target path for templates
+        /// </summary>
+        public const string PackagePath = RootPath + @"Nancy.Templates\ProjectTemplates\CSharp\Web\";
+
+        /// <summary>
+        /// Icon image file used in templates
+        /// </summary>
+        public static readonly TemplateFile IconTemplateFile =
+            new TemplateFile
+            {
+                FilePath = IconImagePath,
+                ZipPath = "__TemplateIcon.jpg",
+                Exclude = true
+            };
+
+        /// <summary>
+        /// Preview image files used in template
+        /// </summary>
+        public static readonly TemplateFile PreviewTemplateFile =
+            new TemplateFile
+            {
+                FilePath = PreviewImagePath,
+                ZipPath = "__PreviewImage.jpg",
+                Exclude = true
+            };
+
+        /// <summary>
+        /// Templates to process
+        /// </summary>
+        public static readonly TemplateConfig[] TemplateConfigProjects =
+        {
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.AspNetHost\Nancy.Templates.CSharp.AspNetHost.csproj",
+                Name = "Nancy Application with ASP.NET hosting",
+                DefaultName = "NancyApplication",
+                Description = "A project for creating a Nancy application that is hosted on ASP.NET",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.AspNetHostWithRazor\Nancy.Templates.CSharp.AspNetHostWithRazor.csproj",
+                Name = "Nancy Application with ASP.NET hosting and Razor",
+                DefaultName = "NancyApplication",
+                Description = "A project for creating a Nancy application with Razor support that is hosted on ASP.NET",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.SelfHost\Nancy.Templates.CSharp.SelfHost.csproj",
+                Name = "Nancy Application with self-hosting",
+                DefaultName = "NancyApplication",
+                Description = "A project for creating a Nancy application that is self-hosted",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.SelfHostWithRazor\Nancy.Templates.CSharp.SelfHostWithRazor.csproj",
+                Name = "Nancy Application with self-hosting and Razor",
+                DefaultName = "NancyApplication",
+                Description = "A project for creating a Nancy application with Razor support that is self-hosted",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.Demo\Nancy.Templates.CSharp.Demo.csproj",
+                Name = "Nancy Demo Application Template",
+                DefaultName = "Nancy.DemoApplication",
+                Description = "A project for creating a Nancy based demo application",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.EmptyAspNetHost\Nancy.Templates.CSharp.EmptyAspNetHost.csproj",
+                Name = "Nancy Empty Application with ASP.NET hosting",
+                DefaultName = "NancyApplication",
+                Description = "An empty project for creating a Nancy application that is hosted on ASP.NET",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName =RootPath + @"Nancy.Templates.CSharp.EmptyAspNetHostingWithRazor\Nancy.Templates.CSharp.EmptyAspNetHostWithRazor.csproj",
+                Name = "Nancy Empty Application with ASP.NET hosting and Razor",
+                DefaultName = "NancyApplication",
+                Description = "An empty project for creating a Nancy application with Razor support that is hosted on ASP.NET",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.EmptySelfHost\Nancy.Templates.CSharp.EmptySelfHost.csproj",
+                Name = "Nancy Empty Application with self-hosting",
+                DefaultName = "NancyApplication",
+                Description = "An empty project for creating a Nancy application that is self-hosted",
+                ProjectType = "CSharp"
+            },
+            new TemplateConfig
+            {
+                ProjectFileName = RootPath + @"Nancy.Templates.CSharp.EmptySelfHostWithRazor\Nancy.Templates.CSharp.EmptySelfHostWithRazor.csproj",
+                Name = "Nancy Empty Application with self-hosting and Razor",
+                DefaultName = "NancyApplication",
+                Description = "An empty project for creating a Nancy application with Razor support that is self-hosted",
+                ProjectType = "CSharp"
+            }
+        };
+    }
+}

--- a/src/Nancy.Templates.sln
+++ b/src/Nancy.Templates.sln
@@ -1,5 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Templates", "Nancy.Templates\Nancy.Templates\Nancy.Templates.csproj", "{676C77CC-2B5C-4C44-8162-658C6A9A8CCC}"
 	ProjectSection(ProjectDependencies) = postProject
 		{E945E104-2687-4637-AE33-6EECBF157E8B} = {E945E104-2687-4637-AE33-6EECBF157E8B}
@@ -30,6 +32,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Templates.CSharp.SelfHostWithRazor", "Nancy.Templates\Nancy.Templates.CSharp.SelfHostWithRazor\Nancy.Templates.CSharp.SelfHostWithRazor.csproj", "{68F5F5F3-B8BB-4911-875F-6F00AAE04EA6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Templates.CSharp.Demo", "Nancy.Templates\Nancy.Templates.CSharp.Demo\Nancy.Templates.CSharp.Demo.csproj", "{E945E104-2687-4637-AE33-6EECBF157E8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.Templates.Builder", "Nancy.Templates.Builder\Nancy.Templates.Builder.csproj", "{5FD39AFA-F3EC-475B-81FA-AA1633963138}"
+	ProjectSection(ProjectDependencies) = postProject
+		{676C77CC-2B5C-4C44-8162-658C6A9A8CCC} = {676C77CC-2B5C-4C44-8162-658C6A9A8CCC}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -77,6 +84,10 @@ Global
 		{E945E104-2687-4637-AE33-6EECBF157E8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E945E104-2687-4637-AE33-6EECBF157E8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E945E104-2687-4637-AE33-6EECBF157E8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FD39AFA-F3EC-475B-81FA-AA1633963138}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FD39AFA-F3EC-475B-81FA-AA1633963138}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FD39AFA-F3EC-475B-81FA-AA1633963138}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FD39AFA-F3EC-475B-81FA-AA1633963138}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Web.config
@@ -1,14 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
-
     <httpHandlers>
       <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </httpHandlers>
   </system.web>
-
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHost/Web.config
@@ -8,6 +8,7 @@
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough"/>
     <handlers>
       <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Nancy.Templates.CSharp.AspNetHostWithRazor.csproj
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Nancy.Templates.CSharp.AspNetHostWithRazor.csproj
@@ -62,9 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\nancy-logo.png" />
-    <Content Include="Web.config">
-      <SubType>Designer</SubType>
-    </Content>
+    <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bootstrapper.cs" />

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Web.config
@@ -22,6 +22,7 @@
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough"/>
     <handlers>
       <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.AspNetHostWithRazor/Web.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
@@ -10,23 +9,23 @@
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
     </sectionGroup>
   </configSections>
-
   <system.web>
     <compilation debug="true" targetFramework="4.0">
-
       <buildProviders>
-        <add extension=".cshtml"
-             type="Nancy.ViewEngines.Razor.BuildProviders.NancyCSharpRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
-        <add extension=".vbhtml"
-             type="Nancy.ViewEngines.Razor.BuildProviders.NancyVisualBasicRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
+        <add extension=".cshtml" type="Nancy.ViewEngines.Razor.BuildProviders.NancyCSharpRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
+        <add extension=".vbhtml" type="Nancy.ViewEngines.Razor.BuildProviders.NancyVisualBasicRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
       </buildProviders>
     </compilation>
-
     <httpHandlers>
       <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </httpHandlers>
   </system.web>
-
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+    <handlers>
+      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </handlers>
+  </system.webServer>
   <appSettings>
     <add key="webPages:Enabled" value="false" />
   </appSettings>
@@ -37,10 +36,4 @@
       </namespaces>
     </pages>
   </system.web.webPages.razor>
-  <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
-    <handlers>
-      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
-    </handlers>
-  </system.webServer>
 </configuration>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.Demo/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.Demo/Web.config
@@ -6,12 +6,10 @@
 <configuration>
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
-
     <httpHandlers>
       <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </httpHandlers>
   </system.web>
-
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHost/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHost/Web.config
@@ -12,6 +12,7 @@
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough"/>
     <handlers>
       <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHost/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHost/Web.config
@@ -6,12 +6,10 @@
 <configuration>
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
-
     <httpHandlers>
       <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </httpHandlers>
   </system.web>
-
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHostingWithRazor/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHostingWithRazor/Web.config
@@ -22,6 +22,7 @@
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
+    <httpErrors existingResponse="PassThrough"/>
     <handlers>
       <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </handlers>

--- a/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHostingWithRazor/Web.config
+++ b/src/Nancy.Templates/Nancy.Templates.CSharp.EmptyAspNetHostingWithRazor/Web.config
@@ -9,21 +9,23 @@
       <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
     </sectionGroup>
   </configSections>
-
   <system.web>
     <compilation debug="true" targetFramework="4.0">
-
       <buildProviders>
         <add extension=".cshtml" type="Nancy.ViewEngines.Razor.BuildProviders.NancyCSharpRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
         <add extension=".vbhtml" type="Nancy.ViewEngines.Razor.BuildProviders.NancyVisualBasicRazorBuildProvider, Nancy.ViewEngines.Razor.BuildProviders" />
       </buildProviders>
     </compilation>
-
     <httpHandlers>
       <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
     </httpHandlers>
   </system.web>
-
+  <system.webServer>
+    <validation validateIntegratedModeConfiguration="false" />
+    <handlers>
+      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
+    </handlers>
+  </system.webServer>
   <appSettings>
     <add key="webPages:Enabled" value="false" />
   </appSettings>
@@ -34,10 +36,4 @@
       </namespaces>
     </pages>
   </system.web.webPages.razor>
-  <system.webServer>
-    <validation validateIntegratedModeConfiguration="false" />
-    <handlers>
-      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
-    </handlers>
-  </system.webServer>
 </configuration>


### PR DESCRIPTION
Added automated template builder, also synced project web.config with what was in the committed template zip files.

Would love to discuss around the concept.

Basically it takes as much as possible from the sample projects to generate the template zip files.

Configuration is currently in code, but goal is to take a tedious task and make part of build process. 

Have WinDiffed current Zip files and currently only found BOM difference will test more and update request if I find any issues.

Regardless how this pull request goes it would be great if the template zip files also were stored unzipped in repo to easily diff what changes between builds. Also easier to compare source projects, was some differences now probably due the manual labor it currently takes to create the templates.
