### PR TITLE
Support for Visual Studio 2015

### DIFF
--- a/src/Nancy.Templates/Nancy.Templates/source.extension.vsixmanifest
+++ b/src/Nancy.Templates/Nancy.Templates/source.extension.vsixmanifest
@@ -20,6 +20,9 @@
       <VisualStudio Version="12.0">
         <Edition>Pro</Edition>
       </VisualStudio>
+      <VisualStudio Version="14.0">
+        <Edition>Pro</Edition>
+      </VisualStudio> 
     </SupportedProducts>
     <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.5" />
   </Identifier>


### PR DESCRIPTION
Apologies for the out of the blue PR. Just a small change that adds Visual Studio 2015 as a supported product to the vsixmanifest so that the templates can be installed in the latest version.